### PR TITLE
Download dwca zip file as binary 

### DIFF
--- a/R/dwca.R
+++ b/R/dwca.R
@@ -221,7 +221,7 @@ dwca_cache_get <- function(url) {
   } else {
     on.exit(unlink(fpath))
     dir.create(finch_cache(), showWarnings = FALSE, recursive = TRUE)
-    utils::download.file(url = url, destfile = fpath, quiet = FALSE)
+    utils::download.file(url = url, destfile = fpath, quiet = FALSE, mode = "wb")
     utils::unzip(fpath, exdir = dirpath)
     return(dirpath)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed mode = "wb" in a call to `download.file` in order for this to work on Windows. Without the fix `unzip` fails.

