### PR TITLE
Update unit tests for new EML release

### DIFF
--- a/tests/testthat/test-dwca_get.R
+++ b/tests/testthat/test-dwca_get.R
@@ -15,7 +15,7 @@ test_that("dwca_get - works with a directory - read=FALSE", {
   expect_is(aa$files, 'list')
   expect_is(aa$highmeta, 'list')
   expect_is(aa$highmeta$occurrence.txt, 'data.frame')
-  expect_is(aa$emlmeta, 'eml')
+  expect_is(aa$emlmeta, 'emld')
   expect_is(aa$data, 'character')
 })
 
@@ -30,7 +30,7 @@ test_that("dwca_get - works with a zip file - read=FALSE", {
   expect_is(aa$files, 'list')
   expect_is(aa$highmeta, 'list')
   expect_is(aa$highmeta$occurrence.txt, 'data.frame')
-  expect_is(aa$emlmeta, 'eml')
+  expect_is(aa$emlmeta, 'emld')
   expect_is(aa$data, 'character')
 })
 
@@ -48,7 +48,7 @@ test_that("dwca_get - works with a url - read=FALSE", {
   expect_is(aa$files, 'list')
   expect_is(aa$highmeta, 'list')
   expect_is(aa$highmeta$taxon.txt, 'data.frame')
-  expect_is(aa$emlmeta, 'eml')
+  expect_is(aa$emlmeta, 'emld')
   expect_is(aa$data, 'character')
   expect_null(names(aa$data))
 


### PR DESCRIPTION
This should fix the test suite for the EML release to CRAN.  (At the moment this will break the unit tests when testing against CRAN EML, but should resolve tests against `ropensci/EML` which will soon be submitted to CRAN).  Thanks!
